### PR TITLE
Fix "undefined reference to xdr_control" when building raidz_test cmd

### DIFF
--- a/cmd/raidz_test/Makefile.am
+++ b/cmd/raidz_test/Makefile.am
@@ -15,6 +15,7 @@ raidz_test_SOURCES = \
 	raidz_bench.c
 
 raidz_test_LDADD = \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libuutil/libuutil.la \
 	$(top_builddir)/lib/libzpool/libzpool.la
 


### PR DESCRIPTION
Fix "undefined reference to xdr_control" when building raidz_test cmd